### PR TITLE
feat: signup

### DIFF
--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/config/JwtConfig.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/config/JwtConfig.java
@@ -1,0 +1,40 @@
+package com.sparta.preonboardingbackendcourse.domain.user.config;
+
+
+import com.sparta.preonboardingbackendcourse.domain.user.util.JwtUtil;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JwtConfig {
+
+    // 시크릿 키
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+
+    // JWT Access 만료시간
+    @Value("${jwt.token.expiration}")
+    private long accessTokenExpiration;
+
+    //JWT Refresh 만료시간
+    @Value("${jwt.refresh.token.expiration}")
+    private long refreshTokenExpiration;
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public long getAccessTokenExpiration() {
+        return accessTokenExpiration;
+    }
+
+    public long getRefreshTokenExpiration() {
+        return refreshTokenExpiration;
+    }
+
+    @PostConstruct
+    public void init() {
+        JwtUtil.init(this);
+    }
+}

--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/config/PasswordConfig.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/config/PasswordConfig.java
@@ -1,0 +1,19 @@
+package com.sparta.preonboardingbackendcourse.domain.user.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * 비밀번호 암호화하는 config
+ */
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() { // passwordEncoder로 빈 등록
+        //BCrypt: 해시함수: 비밀번호 암호화 -> BCryptPasswordEncoder 암호화
+        return new BCryptPasswordEncoder(); // PasswordEncoder는 인터페이스로 주입받음 -> BCryptPasswordEncoder구현체
+    }
+}

--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/config/SecurityConfig.java
@@ -1,0 +1,4 @@
+package com.sparta.preonboardingbackendcourse.domain.user.config;
+
+public class SecurityConfig {
+}

--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/config/SecurityConfig.java
@@ -1,4 +1,52 @@
 package com.sparta.preonboardingbackendcourse.domain.user.config;
 
+import com.sparta.preonboardingbackendcourse.global.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+/**
+ * SecurityConfig- Spring Security 설정
+ */
+@Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    /**
+     * SecurityFilterChain: 보안 설정을 기반으로 SecurityFilterChain 생성
+     *
+     * @param http : HttpSecurity객체로, CSRF 비활성화, 세션 관리, 요청 권한, 필터 추가
+     * @return SecurityFilterChain객체 생성(http 요청의 보안 규칙이 적용된)
+     * @throws Exception
+     */
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        // CSRF 설정
+        http.csrf((csrf) -> csrf.disable())  //csrf 비활성화
+
+                .sessionManagement((sessionManagement) ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 관리를 stateless설정
+
+                // 요청에 대한 권한 설정
+                .authorizeHttpRequests(authorizeHttpRequests ->
+                                authorizeHttpRequests
+                                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
+                                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll() // Swagger 접근 허용
+                                        .requestMatchers(HttpMethod.POST, "/api/auth/**").permitAll() // 로그인, 회원가입 접근 허용
+                        //      .anyRequest().permitAll() // 그 외 모든 요청 접근 허용
+                        //.anyRequest().authenticated() // 그 외 모든 요청 인증처리
+                );
+
+        // jwtAuthenticationFilter의 순서를 지정해주기위해 UsernamePasswordAuthenticationFilter전으로 위치 지정
+        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
 }

--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/controller/AuthController.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.sparta.preonboardingbackendcourse.domain.user.controller;
 
 import com.sparta.preonboardingbackendcourse.domain.user.dto.SignupRequest;
 import com.sparta.preonboardingbackendcourse.domain.user.dto.SignupResponse;
+import com.sparta.preonboardingbackendcourse.domain.user.service.UserService;
 import com.sparta.preonboardingbackendcourse.global.dto.ResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -17,10 +18,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthController {
 
+    private final UserService userService;
+
     // 회원가입
-//    @PostMapping("/signup")
-//    public ResponseEntity<ResponseDto<SignupResponse>> signup(@Valid @RequestBody SignupRequest signupRequest) {}
-//
+    @PostMapping("/signup")
+    public ResponseEntity<ResponseDto<SignupResponse>>signup(@Valid @RequestBody SignupRequest signupRequest) {
+        SignupResponse signupResponse = userService.signup(signupRequest);
+        ResponseDto<SignupResponse> responseDto = new ResponseDto<>(
+                "회원가입 성공", signupResponse);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+
     // 로그인
 
     // 엑세스토큰 재발급

--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/controller/AuthController.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/controller/AuthController.java
@@ -1,0 +1,30 @@
+package com.sparta.preonboardingbackendcourse.domain.user.controller;
+
+import com.sparta.preonboardingbackendcourse.domain.user.dto.SignupRequest;
+import com.sparta.preonboardingbackendcourse.domain.user.dto.SignupResponse;
+import com.sparta.preonboardingbackendcourse.global.dto.ResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/auth")
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    // 회원가입
+//    @PostMapping("/signup")
+//    public ResponseEntity<ResponseDto<SignupResponse>> signup(@Valid @RequestBody SignupRequest signupRequest) {}
+//
+    // 로그인
+
+    // 엑세스토큰 재발급
+
+
+
+}

--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/dto/SignupRequest.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/dto/SignupRequest.java
@@ -1,0 +1,16 @@
+package com.sparta.preonboardingbackendcourse.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class SignupRequest {
+    @NotBlank(message = "닉네임은 필수 입력 값 입니다.")
+    private String nickname;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값 입니다.")
+    private String password;
+
+    @NotBlank(message = "이름은 필수 입력 값 입니다.")
+    private String username;
+}

--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/dto/SignupResponse.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/dto/SignupResponse.java
@@ -8,14 +8,14 @@ import java.util.List;
 @Getter
 public class SignupResponse {
 
-    private final String username;
     private final String nickname;
     private final List<String> authorities;
+    private final String username;
 
     @Builder
-    public SignupResponse(String username, String nickname, List<String> authorities) {
-        this.username = username;
+    public SignupResponse(String nickname, String username, List<String> authorities) {
         this.nickname = nickname;
+        this.username = username;
         this.authorities = authorities;
     }
 }

--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/dto/SignupResponse.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/dto/SignupResponse.java
@@ -1,0 +1,21 @@
+package com.sparta.preonboardingbackendcourse.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class SignupResponse {
+
+    private final String username;
+    private final String nickname;
+    private final List<String> authorities;
+
+    @Builder
+    public SignupResponse(String username, String nickname, List<String> authorities) {
+        this.username = username;
+        this.nickname = nickname;
+        this.authorities = authorities;
+    }
+}

--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/entity/Role.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/entity/Role.java
@@ -1,0 +1,38 @@
+package com.sparta.preonboardingbackendcourse.domain.user.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Role {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    // role과 user role
+    @OneToMany(mappedBy = "role", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnore // 순환 참조 방지
+    private Set<UserRole> userRoles = new HashSet<>();
+
+    @Builder
+    public Role(String name) {
+        this.name = name;
+    }
+
+    public void addUserRole(UserRole userRole) {
+        userRoles.add(userRole);
+    }
+}

--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/entity/User.java
@@ -1,0 +1,61 @@
+package com.sparta.preonboardingbackendcourse.domain.user.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.Set;
+
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String userNickname;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private UserStatus userStatus;
+
+    //유저와 유저롤
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnore
+    private Set<UserRole> roles = new HashSet<>();
+
+    @Builder
+    public User(String password, String username, String userNickname, UserStatus userStatus) {
+        this.password = password;
+        this.username = username;
+        this.userNickname = userNickname;
+        this.userStatus = userStatus;
+    }
+
+    public void login() {
+        this.userStatus = UserStatus.ACTIVE;
+    }
+
+    // 역할 추가 메서드
+    public void addRole(Role role) {
+        UserRole userRole = UserRole.builder()
+                .user(this)
+                .role(role)
+                .build();
+        roles.add(userRole);
+    }
+}
+

--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/entity/UserRole.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/entity/UserRole.java
@@ -1,0 +1,32 @@
+package com.sparta.preonboardingbackendcourse.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_role")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserRole {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "role_id", nullable = false)
+    private Role role;
+
+    @Builder
+    public UserRole(User user, Role role) {
+        this.user = user;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/entity/UserStatus.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/entity/UserStatus.java
@@ -1,0 +1,8 @@
+package com.sparta.preonboardingbackendcourse.domain.user.entity;
+
+public enum UserStatus {
+    PENDING,
+    ACTIVE,
+    LOGOUT,
+    WITHDRAWN,
+}

--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/repository/RoleRepository.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/repository/RoleRepository.java
@@ -1,0 +1,11 @@
+package com.sparta.preonboardingbackendcourse.domain.user.repository;
+
+import com.sparta.preonboardingbackendcourse.domain.user.entity.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoleRepository extends JpaRepository<Role, Long> {
+    Role findByName(String name);
+}
+

--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/repository/UserRepository.java
@@ -1,0 +1,17 @@
+package com.sparta.preonboardingbackendcourse.domain.user.repository;
+
+import com.sparta.preonboardingbackendcourse.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    // 이름 중복 여부 확인
+    boolean existsByUsername(String username);
+
+    // 이름으로 사용자 찾기
+    Optional<User> findByUsername(String username);
+
+}
+

--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/repository/UserRoleRepository.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/repository/UserRoleRepository.java
@@ -1,0 +1,12 @@
+package com.sparta.preonboardingbackendcourse.domain.user.repository;
+
+import com.sparta.preonboardingbackendcourse.domain.user.entity.User;
+import com.sparta.preonboardingbackendcourse.domain.user.entity.UserRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserRoleRepository extends JpaRepository<UserRole, Long> {
+
+    List<UserRole> findByUser(User user);
+}

--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/service/RoleService.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/service/RoleService.java
@@ -1,0 +1,16 @@
+package com.sparta.preonboardingbackendcourse.domain.user.service;
+
+import com.sparta.preonboardingbackendcourse.domain.user.entity.Role;
+import com.sparta.preonboardingbackendcourse.domain.user.repository.RoleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RoleService {
+
+    private final RoleRepository roleRepository;
+    public Role findRoleByName(String name) {
+        return roleRepository.findByName(name);
+    }
+}

--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/service/UserRoleService.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/service/UserRoleService.java
@@ -1,0 +1,41 @@
+package com.sparta.preonboardingbackendcourse.domain.user.service;
+
+import com.sparta.preonboardingbackendcourse.domain.user.entity.Role;
+import com.sparta.preonboardingbackendcourse.domain.user.entity.User;
+import com.sparta.preonboardingbackendcourse.domain.user.entity.UserRole;
+import com.sparta.preonboardingbackendcourse.domain.user.repository.UserRoleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * UserRoleServiceImpl: 유저 역할을 연결
+ */
+@Service
+@RequiredArgsConstructor
+public class UserRoleService {
+
+    private final UserRoleRepository userRoleRepository;
+    private final RoleService roleService;
+
+    public void addUserRole(User user, String roleName) {
+
+        Role role = roleService.findRoleByName(roleName);
+
+        UserRole userRole = UserRole.builder()
+                .user(user)
+                .role(role)
+                .build();
+
+        userRoleRepository.save(userRole);
+    }
+
+    // 사용자의 권한 목록 조회
+    public List<String> getUserRoles(User user) {
+        return userRoleRepository.findByUser(user).stream()
+                .map(userRole -> userRole.getRole().getName())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/service/UserService.java
@@ -1,0 +1,9 @@
+package com.sparta.preonboardingbackendcourse.domain.user.service;
+
+import com.sparta.preonboardingbackendcourse.domain.user.dto.SignupRequest;
+import com.sparta.preonboardingbackendcourse.domain.user.dto.SignupResponse;
+
+public interface UserService {
+    // 회원가입
+    SignupResponse signup(SignupRequest signupRequest);
+}

--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/service/UserServiceImpl.java
@@ -47,9 +47,8 @@ public class UserServiceImpl implements UserService{
 
         return SignupResponse.builder()
                 .username(user.getUsername())
-                .nickname(signupRequest.getUsername())
+                .nickname(user.getUserNickname())
                 .authorities(authorities)
                 .build();
-
     }
 }

--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,55 @@
+package com.sparta.preonboardingbackendcourse.domain.user.service;
+
+import com.sparta.preonboardingbackendcourse.domain.user.dto.SignupRequest;
+import com.sparta.preonboardingbackendcourse.domain.user.dto.SignupResponse;
+import com.sparta.preonboardingbackendcourse.domain.user.entity.User;
+import com.sparta.preonboardingbackendcourse.domain.user.entity.UserStatus;
+import com.sparta.preonboardingbackendcourse.domain.user.repository.UserRepository;
+
+import com.sparta.preonboardingbackendcourse.global.exception.CustomException;
+import com.sparta.preonboardingbackendcourse.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService{
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final UserRoleService userRoleService;
+
+    @Override
+    public SignupResponse signup(SignupRequest signupRequest) {
+
+        // 이미 존재하는 사용자 확인
+        if (userRepository.existsByUsername(signupRequest.getUsername())) {
+            throw new CustomException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+        // 비밀번호 인코딩
+        String encodedPassword = passwordEncoder.encode(signupRequest.getPassword());
+        User user = User.builder()
+                .password(encodedPassword)
+                .username(signupRequest.getUsername())
+                .userNickname(signupRequest.getNickname())
+                .userStatus(UserStatus.PENDING) // 사용자 상태 비활성화 -> 로그인하면 그때 활성화시킬것
+                .build();
+
+        userRepository.save(user);
+
+        // 권한 지정
+        userRoleService.addUserRole(user,"USER"); // 지금은 임시로 USER로 권한 들어가게
+
+        // 권한 정보 조회
+        List<String> authorities = userRoleService.getUserRoles(user);
+
+        return SignupResponse.builder()
+                .username(user.getUsername())
+                .nickname(signupRequest.getUsername())
+                .authorities(authorities)
+                .build();
+
+    }
+}

--- a/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/util/JwtUtil.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/domain/user/util/JwtUtil.java
@@ -1,0 +1,132 @@
+package com.sparta.preonboardingbackendcourse.domain.user.util;
+
+
+import com.sparta.preonboardingbackendcourse.domain.user.config.JwtConfig;
+import com.sparta.preonboardingbackendcourse.domain.user.entity.UserRole;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+public class JwtUtil {
+
+    private static String secretKey;
+    private static long accessTokenExpiration;
+    private static long refreshTokenExpiration;
+
+    private JwtUtil() {
+    }
+
+    public static void init(JwtConfig jwtConfig) {
+        secretKey = Base64.getEncoder().encodeToString(jwtConfig.getSecretKey().getBytes());
+        accessTokenExpiration = jwtConfig.getAccessTokenExpiration();
+        refreshTokenExpiration = jwtConfig.getRefreshTokenExpiration();
+    }
+
+    /**
+     * 사용자 이름으로 엑세스 토큰 발급
+     *
+     * @param username
+     * @return
+     */
+    public static String createAccessToken(String username, Set<UserRole> roles) {
+        return generateToken(username, accessTokenExpiration, roles);
+    }
+
+    /**
+     * 사용자 이름으로 리프레시 토큰 발급
+     *
+     * @param username
+     * @return
+     */
+    public static String createRefreshToken(String username) {
+        return generateToken(username, refreshTokenExpiration, null);
+    }
+
+    /**
+     * 리프레시 토큰 반환시간
+     * @return
+     */
+    public static long getRefreshTokenExpiration() {
+        return refreshTokenExpiration;
+    }
+
+    /**
+     * 토큰 생성 내부 메서드
+     *
+     * @param username
+     * @param expiration
+     * @return
+     */
+    public static String generateToken(String username, long expiration, Set<UserRole> roles) {
+        JwtBuilder builder = Jwts.builder()
+                .setSubject(username) // 토큰 주체
+                .claim("roles", roles)
+                .setIssuedAt(new Date()) // 토큰 발행 시간
+                .setExpiration(new Date(System.currentTimeMillis() + expiration)) // 토큰 만료시간
+                .signWith(SignatureAlgorithm.HS256, secretKey);
+
+        if (roles != null) {
+            builder.claim("roles", roles);
+        }
+
+        return builder.compact();
+    }
+
+    /**
+     * JWT 토큰에서 Claims을 추출
+     *
+     * @param token JWT 토큰
+     * @return 토큰에서 추출한 Claims 객체
+     */
+    public static Claims extractClaims(String token) {
+        return Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    // 토큰유효성 검사
+    public static boolean validateToken(String token, UserDetails userDetails) {
+        // 토큰에서 사용자 이름 추출
+        final String username = getUsernameFromToken(token);
+        // 토큰 검사(이름 일치, 만료 확인)
+        return (username.equals(userDetails.getUsername()) && !isTokenExpired(token));
+    }
+
+    /**
+     * 토큰 만료일 claim 추출
+     *
+     * @param token JWT 토큰
+     * @return 현재 시간
+     */
+    private static boolean isTokenExpired(String token) {
+        final Date expiration = extractClaims(token).getExpiration();
+        return expiration.before(new Date());
+    }
+
+    // 사용자 추출
+    public static String getUsernameFromToken(String token) {
+        return extractClaims(token).getSubject();
+    }
+
+
+    public static List<SimpleGrantedAuthority> getRolesFromToken(String token) {
+        Claims claims = extractClaims(token);
+        List<String> roles = claims.get("roles", List.class);
+        return roles.stream()
+                .map(role -> new SimpleGrantedAuthority("ROLE_" + role)) // ROLE_ 접두사 추가
+                .collect(Collectors.toList());
+    }
+}
+

--- a/src/main/java/com/sparta/preonboardingbackendcourse/global/config/SwaggerConfig.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/global/config/SwaggerConfig.java
@@ -1,0 +1,31 @@
+package com.sparta.preonboardingbackendcourse.global.config;
+
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * SwaggerConfig : - open API정보를 가진 객체 생성해서 api 문서 생성
+ */
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+
+        return new OpenAPI()
+                // api 기본 정보
+                .info(new Info()
+                        .title("Pre-onboarding Backend Course API")
+                        .version("1.0")
+                        .description("Pre-onboarding Backend Course의 API 문서입니다"))
+
+                // 서버 정보 추가 - 로컬로
+                .addServersItem(new Server().url("http://localhost:8080")
+                        .description("Local server"));
+    }
+}
+

--- a/src/main/java/com/sparta/preonboardingbackendcourse/global/dto/ResponseDto.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/global/dto/ResponseDto.java
@@ -1,0 +1,17 @@
+package com.sparta.preonboardingbackendcourse.global.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ResponseDto<T> {
+    private String message;
+    private T data;
+
+    @Builder
+    public ResponseDto(String message, T data) {
+        this.message = message;
+        this.data = data;
+    }
+}
+

--- a/src/main/java/com/sparta/preonboardingbackendcourse/global/exception/CustomException.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/global/exception/CustomException.java
@@ -1,0 +1,16 @@
+package com.sparta.preonboardingbackendcourse.global.exception;
+
+import lombok.Getter;
+
+/**
+ * CustomException - 에러코드와 메시지 커스텀 exception
+ */
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/sparta/preonboardingbackendcourse/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/global/exception/ErrorCode.java
@@ -1,0 +1,22 @@
+package com.sparta.preonboardingbackendcourse.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode {
+
+    // user 관련 오류 처리
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용중인 닉네임입니다."),
+    DUPLICATE_USER_ID(HttpStatus.CONFLICT, "이미 사용중인 ID입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
+    LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "로그인에 실패했습니다."),
+    WRONG_HTTP_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 HTTP 요청입니다."),
+    INCORRECT_PASSWORD(HttpStatus.BAD_REQUEST, "현재 비밀번호가 일치하지 않습니다."),
+    REFRESH_TOKEN_NOT_VALIDATE(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었거나 잘못되었습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/sparta/preonboardingbackendcourse/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,33 @@
+package com.sparta.preonboardingbackendcourse.global.exception;
+
+import com.sparta.preonboardingbackendcourse.global.dto.ResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    //valid 에러 처리:
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ResponseDto<String>> handleValidationException(MethodArgumentNotValidException ex) {
+        ResponseDto<String> errorResponse = ResponseDto.<String>builder()
+                .message(ex.getMessage())
+                .data(null)
+                .build();
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    // CustomException 처리
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ResponseDto<String>> handleCustomException(CustomException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        ResponseDto<String> errorResponse = ResponseDto.<String>builder()
+                .message(errorCode.getMessage())
+                .data(null)
+                .build();
+        return new ResponseEntity<>(errorResponse, errorCode.getStatus());
+    }
+}

--- a/src/main/java/com/sparta/preonboardingbackendcourse/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/preonboardingbackendcourse/global/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,75 @@
+package com.sparta.preonboardingbackendcourse.global.filter;
+
+import com.sparta.preonboardingbackendcourse.domain.user.util.JwtUtil;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final UserDetailsService userDetailsService;
+
+    /**
+     * 요청 필터링: JWT 토큰을 검증해서 유효하면 사용자 정보 설정
+     *
+     * @param request  HTTP 요청
+     * @param response HTTP 응답
+     * @param chain    필터 체인
+     * @throws ServletException
+     * @throws IOException
+     */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        // 요청헤더에서 Authorization 추출
+        final String authorizationHeader = request.getHeader("Authorization");
+
+        String username = null;
+        String jwt = null;
+
+        if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            jwt = authorizationHeader.substring(7);
+            try {
+                username = JwtUtil.getUsernameFromToken(jwt);
+            } catch (ExpiredJwtException e) {
+                // JWT 토큰이 만료된 경우
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, " 토큰이 만료되었습니다.");
+                return;
+            }
+        }
+
+        // JWT 토큰이 유효한 경우
+        if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails userDetails = this.userDetailsService.loadUserByUsername(username);
+
+            if (JwtUtil.validateToken(jwt, userDetails)) {
+                List<SimpleGrantedAuthority> authorities = JwtUtil.getRolesFromToken(jwt);
+                System.out.println("권한: " + authorities);
+
+                UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                        new UsernamePasswordAuthenticationToken(userDetails, null, authorities);
+                usernamePasswordAuthenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+            }
+        }
+        // 다음 필터로 요청을 전달
+        chain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> [feat 1 -signup](https://github.com/dami0806/Preonboarding-Backend-Course/issues/1#issue-2502018906)


## 📝작업 내용

> 작업한 내용 간략한 설명
- USER,Role을 각각 엔티티로 만들어 중간엔티티를 사용해서 유저에 권한을 부여했습니다.
- 시큐리티를 사용해서 CSRF, 접근 권한을 설정했습니다.
- 세션을 유지하지 않고 JWT를 통해 인증을 처리하기 위해 Stateless를 설정했습니다.
- 사용자는 회원가입을 할수 있 수 있고, 실패시 에러메시지를 볼수 있습니다.

### 스크린샷
<img width="690" alt="image" src="https://github.com/user-attachments/assets/db7cb21f-73d5-4c98-86fe-c709b5a8b465">

<img width="834" alt="image" src="https://github.com/user-attachments/assets/240431a1-016e-49e4-b4bc-1945f16251a2">



